### PR TITLE
feat: :sparkles: Made usage data more readable #20

### DIFF
--- a/html/compilerfailurerates.html
+++ b/html/compilerfailurerates.html
@@ -4,7 +4,7 @@
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="/conan.css" />
+    <link rel="stylesheet" href="./conan.css" />
     <script language="Javascript">
         const urlprefix = "https://conan.compiler-explorer.com";
         function refreshCompilers() {

--- a/html/conan.css
+++ b/html/conan.css
@@ -1,3 +1,7 @@
+:root {
+    --black: rgba(0,0,0, 0.8);;
+}
+
 a.libraryversion {
     padding-right: 10px;
 }
@@ -15,4 +19,35 @@ tr.compilerrow td {
 }
 body div.popover {
     max-width: 400px;
+}
+
+#tooltip {
+    position: absolute;
+    display: inline-block;
+    height: auto;
+    font-size: 12px;
+    background-color: var(--black);
+    padding: 10px 8px;
+    border-radius: 6px;
+    color: white;
+}
+
+#tooltip.hidden {
+    display: none;
+}
+#tooltip .library  {
+    font-weight: bold;
+    line-height: 20px;
+}
+
+#box-arrow {
+    position: absolute;
+    width: 0;
+    height: 0;
+    left: -10px;
+    top: 17px;
+    border-top: 10px solid transparent;
+    border-bottom: 10px solid transparent; 
+
+    border-right:10px solid var(--black);
 }

--- a/html/failedbuilds.html
+++ b/html/failedbuilds.html
@@ -4,7 +4,7 @@
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="/conan.css" />
+    <link rel="stylesheet" href="./conan.css" />
     <script language="Javascript">
         const urlprefix = "";
         let failedbuilds = [];

--- a/html/index.html
+++ b/html/index.html
@@ -4,7 +4,7 @@
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="/conan.css" />
+    <link rel="stylesheet" href="./conan.css" />
     <title>CE - Library binaries</title>
 </head>
 <body>

--- a/html/libraries.html
+++ b/html/libraries.html
@@ -4,7 +4,7 @@
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="/conan.css" />
+    <link rel="stylesheet" href="./conan.css" />
     <script language="Javascript">
         const urlprefix = "https://conan.compiler-explorer.com";
         function refreshLibraries() {

--- a/html/libraries_cpp.html
+++ b/html/libraries_cpp.html
@@ -4,7 +4,7 @@
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="/conan.css" />
+    <link rel="stylesheet" href="./conan.css" />
     <script language="Javascript">
         const urlprefix = "https://conan.compiler-explorer.com";
         function refreshLibraries() {

--- a/html/libraries_rust.html
+++ b/html/libraries_rust.html
@@ -4,7 +4,7 @@
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="/conan.css" />
+    <link rel="stylesheet" href="./conan.css" />
     <script language="Javascript">
         const urlprefix = "https://conan.compiler-explorer.com";
         function refreshLibraries() {

--- a/html/usage-d3.html
+++ b/html/usage-d3.html
@@ -103,7 +103,6 @@
 
             var xScale = d3.scaleLinear()
                             .range([0, width])
-                            // .padding(0.5)
             var   yScale = d3.scaleBand()
                             .range([0, height]).padding(0.3)
 
@@ -144,7 +143,7 @@
             // and that which will not be on the chart
             let dataOnChart = filteredUsageData.filter(x => x.usage >= minRange);
             let dataNotOnChart = filteredUsageData.filter(x => x.usage < minRange)
-            // console.log(dataOnChart)
+
             
             // Display libraries not on chart as un-ordered list
             dataNotOnChart.forEach( info => {

--- a/html/usage-d3.html
+++ b/html/usage-d3.html
@@ -1,0 +1,221 @@
+<html>
+
+<head>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
+        integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+    <link rel="stylesheet" href="./conan.css" />
+    
+    <title>CE - Library binaries usage data</title>
+    <style>
+        
+
+    </style>
+</head>
+
+<body>
+    <!-- <canvas id="chart"></canvas> -->
+    <div id="tooltip" class="hidden">
+        <div id="box-arrow"></div>
+        <span class="library">Library</span> <br />
+        <span class="usage">Value</span>
+        
+    </div>
+    <svg width="800" height="700"></svg>
+
+    <div>&nbsp;</div>
+    <div class="mx-4">
+        <h3><strong>About this graph</strong></h3>
+        <p>
+            This graph shows a snapshot (<em>between <span id="from"></span> and <span id="to"></span></em>) of library usage (unsorted) when using Binary mode or Execution of Cpp libraries (red bars),
+            and for the Rust libraries (blue bars) it shows all usage.
+        </p>
+        <h4>Libraries not displayed on the chart</h4>
+        <p>
+            <ul id="notOnChart"></ul>
+
+        </p>
+        <p>
+            It does not contain all library usage, none of the header-only libraries are included, and some libraries are not stored in conan (openssl, hdf5, libuv, lua, nsimd).
+        </p>
+    </div>
+
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+        integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+        crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
+        integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
+        crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js"
+        integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI"
+        crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/5.7.0/d3.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/underscore@1.13.4/underscore-umd-min.js"></script>
+    
+    <script language="Javascript">
+        const urlprefix = 'https://conan.compiler-explorer.com';
+        let chart;
+        let cpplibraries;
+        let rustlibraries;
+        const minRange = 20;
+
+        function loadChart() {
+            
+            d3.csv('https://compiler-explorer.s3.amazonaws.com/public/library_usage.csv')
+                .then(data => {
+                    makeChart(data)
+                });
+        }
+
+        function loadCppLibraries(done) {
+            fetch(urlprefix + '/libraries/cpp' , {
+                    method: 'GET',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    }
+                })
+                .then(response => response.json())
+                .then(info => {
+                    cpplibraries = Object.keys(info)
+                    done[0](done.slice(1));
+                })
+        }
+
+        function loadRustLibraries(done) {
+            
+            fetch(urlprefix + '/libraries/rust', {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            })
+            .then(info => {
+                rustlibraries = Object.keys(info)
+                done[0](done.slice(1))
+            })
+        }
+
+        function makeChart(usage) {
+            var svg = d3.select("svg"),
+            margin = {top: 20, right: 30, bottom: 40, left: 90},
+            width = svg.attr("width") - margin.left - margin.right,
+            height = svg.attr("height") - margin.top - margin.bottom;
+
+            var xScale = d3.scaleLinear()
+                            .range([0, width])
+                            // .padding(0.5)
+            var   yScale = d3.scaleBand()
+                            .range([0, height]).padding(0.3)
+
+            var g = svg.append("g").attr("transform", "translate("+ margin.left+","+margin.top+")")
+
+
+            const libraries = _.unique(usage.map((d) => d.library));
+
+            const minDate = new Date(_.min(usage.map((d) => Date.parse(d.first_used))));
+            const maxDate = new Date(_.max(usage.map((d) => Date.parse(d.last_used))));
+
+            $('#from').html(minDate.toDateString());
+            $('#to').html(maxDate.toDateString());
+
+
+            // Filter the library usage to get its total_usage as well as color and category
+            let filteredUsageData = libraries.map((lib) => {
+                    var usageData = usage.filter((d) => (d.library === lib));
+                    // Set the color for the library
+                    const color = cpplibraries.includes(lib) ? 'rgba(255, 0, 0, 0.2)'
+                                                    : rustlibraries.includes(lib) ? 'rgba(0, 0, 255, 0.2)' 
+                                                    : 'rgba(127, 127, 127, 0.2)';
+                    // Set the category for which the library belongs
+                    const category = cpplibraries.includes(lib) ? 'cpp'
+                                                    : rustlibraries.includes(lib) ? 'rust' 
+                                                    : 'others';
+                    return {
+                        'library': lib,
+                        color,
+                        category,
+                        'usage': _.reduce(usageData, (memo, d) => {
+                            return memo + parseInt(d.times_used);
+                            }, 0),
+                        }
+                    })
+            
+            // Get the libraries to display on chart 
+            // and that which will not be on the chart
+            let dataOnChart = filteredUsageData.filter(x => x.usage >= minRange);
+            let dataNotOnChart = filteredUsageData.filter(x => x.usage < minRange)
+            // console.log(dataOnChart)
+            
+            // Display libraries not on chart as un-ordered list
+            dataNotOnChart.forEach( info => {
+                $('#notOnChart').append(`<li> ${info.library} (${info.category}) - ${info.usage} </li>`)
+            })
+            
+            
+            // console.log(d3.max(dataOnChart.map(d => d.usage)))
+            xScale.domain([0, d3.max(dataOnChart.map(d => d.usage))])
+            yScale.domain(dataOnChart.map(d => d.library))
+
+            g.append("g").attr("transform", "translate(0," + height +")")
+                    .call(d3.axisBottom(xScale))
+            g.append("g").call(d3.axisLeft(yScale))
+
+            svg.selectAll("myRect")
+                            .data(dataOnChart)
+                            .enter()
+                            .append("rect")
+                            .on("mouseover", onMouseOver)
+                            .on("mouseout", onMouseOut)
+                            .attr("x", d => xScale(350))
+                            .attr("y", (d) => yScale(d.library)+20)
+                            .transition()
+                            .ease(d3.easeLinear)
+                            .duration(800)
+                            .delay((d, i) => i*50)
+                            .attr("width",  (d) => xScale(d.usage))
+                            .attr("height", yScale.bandwidth())
+                            .attr("fill", (d) => d.color)
+                            
+            function onMouseOver(d, i) {
+                let posX = parseFloat(d3.select(this).attr("x")) + xScale(d.usage) + 10
+                let posY = parseFloat(d3.select(this).attr("y")) - yScale.bandwidth() / 2
+                
+
+                d3.select("#tooltip")
+                    .style("left", posX + "px")
+                    .style("top", posY + "px")
+                    .select(".library").text(d.library)
+                d3.select("#tooltip").select(".usage").text(d.usage)
+
+                d3.select("#tooltip").classed("hidden", false)
+
+                d3.select(this)
+                    .transition()
+                    .duration(300)
+                    .attr("y", (d) => yScale(d.library) + 17)
+                    .attr("width", (d) => xScale(d.usage) + 5)
+                    .attr('height', yScale.bandwidth() + 6)
+            }
+            
+            function onMouseOut(d, i) {
+                d3.select(this)
+                    .transition()
+                    .duration(500)
+                    .attr("y", (d) => yScale(d.library)+20)
+                    .attr("width", (d) => xScale(d.usage))
+                    .attr('height', yScale.bandwidth())
+                
+                d3.select("#tooltip").classed("hidden", true)
+            }
+
+        }
+
+        
+
+        $(document).ready(function () {
+            loadCppLibraries([loadRustLibraries, loadChart]);
+        });
+    </script>
+</body>
+
+</html>

--- a/html/usage.html
+++ b/html/usage.html
@@ -110,7 +110,7 @@
             // and that which will not be on the chart
             let dataOnChart = filteredUsageData.filter(x => x.usage >= minRange);
             let dataNotOnChart = filteredUsageData.filter(x => x.usage < minRange)
-            console.log(dataOnChart)
+            
             
             // Display libraries not on chart as un-ordered list
             dataNotOnChart.forEach( info => {
@@ -121,8 +121,6 @@
                 data: dataOnChart.map(x => x.usage),
                 backgroundColor: dataOnChart.map(x => x.color)
             }];
-
-            // console.log(datasets)
 
             var chart = new Chart('chart', {
                 type: 'horizontalBar',

--- a/html/usage.html
+++ b/html/usage.html
@@ -15,31 +15,46 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/5.7.0/d3.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/underscore@1.13.4/underscore-umd-min.js"></script>
-    <link rel="stylesheet" href="/conan.css" />
+    <link rel="stylesheet" href="./conan.css" />
     <script language="Javascript">
         const urlprefix = 'https://conan.compiler-explorer.com';
         let chart;
         let cpplibraries;
         let rustlibraries;
+        const minRange = 20;
 
         function loadChart() {
             d3.csv('https://compiler-explorer.s3.amazonaws.com/public/library_usage.csv')
-                .then(makeChart);
+                .then(data => {
+                    makeChart(data)
+                });
         }
 
         function loadCppLibraries(done) {
-            const xhr = new XMLHttpRequest();
-            xhr.open('GET', urlprefix + '/libraries/cpp');
-            xhr.setRequestHeader('Content-Type', 'application/json');
-            xhr.onload = () => {
-                const info = JSON.parse(xhr.responseText);
-                cpplibraries = Object.keys(info);
-                done[0](done.slice(1));
-            };
-            xhr.send();
+            // const xhr = new XMLHttpRequest();
+            // xhr.open('GET', urlprefix + '/libraries/cpp');
+            // xhr.setRequestHeader('Content-Type', 'application/json');
+            // xhr.onload = () => {
+            //     const info = JSON.parse(xhr.responseText);
+            //     cpplibraries = Object.keys(info);
+            //     done[0](done.slice(1));
+            // };
+            // xhr.send();
+            fetch(urlprefix + '/libraries/cpp' , {
+                    method: 'GET',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    }
+                })
+                .then(response => response.json())
+                .then(info => {
+                    cpplibraries = Object.keys(info)
+                    done[0](done.slice(1));
+                })
         }
 
         function loadRustLibraries(done) {
+            
             const xhr = new XMLHttpRequest();
             xhr.open('GET', urlprefix + '/libraries/rust');
             xhr.setRequestHeader('Content-Type', 'application/json');
@@ -70,20 +85,49 @@
                 }
             });
 
-            var datasets = [{
-                data: libraries.map((lib) => {
-                    var filteredUsageData = usage.filter((d) => d.library === lib);
-                    return _.reduce(filteredUsageData, (memo, d) => {
+            // Filter the library usage to get its total_usage as well as color and category
+            let filteredUsageData = libraries.map((lib) => {
+                    var usageData = usage.filter((d) => (d.library === lib));
+                    // Set the color for the library
+                    const color = cpplibraries.includes(lib) ? 'rgba(255, 0, 0, 0.2)'
+                                                    : rustlibraries.includes(lib) ? 'rgba(0, 0, 255, 0.2)' 
+                                                    : 'rgba(127, 127, 127, 0.2)';
+                    // Set the category for which the library belongs
+                    const category = cpplibraries.includes(lib) ? 'cpp'
+                                                    : rustlibraries.includes(lib) ? 'rust' 
+                                                    : 'others';
+                    return {
+                        'library': lib,
+                        color,
+                        category,
+                        'usage': _.reduce(usageData, (memo, d) => {
                             return memo + parseInt(d.times_used);
-                        }, 0);
-                    }),
-                backgroundColor: colors
+                            }, 0),
+                        }
+                    })
+            
+            // Get the libraries to display on chart 
+            // and that which will not be on the chart
+            let dataOnChart = filteredUsageData.filter(x => x.usage >= minRange);
+            let dataNotOnChart = filteredUsageData.filter(x => x.usage < minRange)
+            console.log(dataOnChart)
+            
+            // Display libraries not on chart as un-ordered list
+            dataNotOnChart.forEach( info => {
+                $('#notOnChart').append(`<li> ${info.library} (${info.category}) - ${info.usage} </li>`)
+            })
+            
+            var datasets = [{
+                data: dataOnChart.map(x => x.usage),
+                backgroundColor: dataOnChart.map(x => x.color)
             }];
+
+            // console.log(datasets)
 
             var chart = new Chart('chart', {
                 type: 'horizontalBar',
                 data: {
-                    labels: libraries,
+                    labels: libraries.slice(0, dataOnChart.length),
                     datasets: datasets
                 },
                 options: {
@@ -111,11 +155,16 @@
     <canvas id="chart"></canvas>
 
     <div>&nbsp;</div>
-    <div>
-        <p><strong>About this graph</strong></p>
+    <div class="mx-4">
+        <h3><strong>About this graph</strong></h3>
         <p>
             This graph shows a snapshot (<em>between <span id="from"></span> and <span id="to"></span></em>) of library usage (unsorted) when using Binary mode or Execution of Cpp libraries (red bars),
             and for the Rust libraries (blue bars) it shows all usage.
+        </p>
+        <h4>Libraries not displayed on the chart</h4>
+        <p>
+            <ul id="notOnChart"></ul>
+
         </p>
         <p>
             It does not contain all library usage, none of the header-only libraries are included, and some libraries are not stored in conan (openssl, hdf5, libuv, lua, nsimd).


### PR DESCRIPTION
Made the usage data for the various libraries more readable by setting a minimum range of 20 per time usage. 
Also listed out the other libraries that cannot be viewed on the chart, so users could see what libraries are used the less.

Lastly, added a HTML page (usage-d3.html) to display the chart with d3.js but not with chart.js

Noticed the css file was not properly linked and  fixed that too